### PR TITLE
remove meta_query for posts populating the current/next show dropdown

### DIFF
--- a/lib/theme-options/site-options.php
+++ b/lib/theme-options/site-options.php
@@ -28,21 +28,10 @@ $metabox = array(
       'options' => get_post_objects(
         array(
           'post_type' => 'evento',
+          'numberposts' => -1,
           'meta_key' => '_igv_evento_start',
           'order' => 'ASC',
           'orderby' => 'meta_value',
-          'meta_query' => array(
-            array(
-              'key'     => '_igv_evento_start',
-        			'value'   => current_time('timestamp') - (60 * 60 * 6), // UTC -5, 6 hours ago
-        			'compare' => '>',
-            ),
-            array(
-              'key'     => '_igv_evento_start',
-        			'value'   => current_time('timestamp') + (60 * 60 * 24), // UTC -5, 24 hours later
-        			'compare' => '<',
-            )
-          )
         )
       )
     ),


### PR DESCRIPTION
This fixes the issue of updating something in Site Options and overwriting the current/next show with an empty value. The select was getting repopulated and sometimes, when the previously show was too old it was getting removed from the options.